### PR TITLE
Update run_models.sh

### DIFF
--- a/.buildkite/scripts/run_models.sh
+++ b/.buildkite/scripts/run_models.sh
@@ -20,7 +20,7 @@ dbt seed --target "$db" --full-refresh
 dbt compile --target "$db"
 dbt run --target "$db" --full-refresh
 dbt test --target "$db"
-dbt run --vars '{recharge_using_orders: false, recharge__one_time_product_enabled: false, recharge__address_passthrough_columns: [cart_attribute_id]}' --target "$db" --full-refresh
-dbt test --vars '{recharge_using_orders: false, recharge__one_time_product_enabled: false, recharge__address_passthrough_columns: [cart_attribute_id]}' --target "$db"
+dbt run --vars '{recharge__using_orders: false, recharge__one_time_product_enabled: false, recharge__address_passthrough_columns: [cart_attribute_id]}' --target "$db" --full-refresh
+dbt test --vars '{recharge__using_orders: false, recharge__one_time_product_enabled: false, recharge__address_passthrough_columns: [cart_attribute_id]}' --target "$db"
 
 dbt run-operation fivetran_utils.drop_schemas_automation --target "$db"


### PR DESCRIPTION
Small PR to adjust the BuildKite tests to properly test the `recharge__using_orders` being enabled/disabled.

For validation, you can see [here](https://github.com/fivetran/dbt_recharge_source/blob/5d227a81a5c83d4fef91e0a3e6529b54bb4b4b2b/models/tmp/stg_recharge__order_tmp.sql#L4) that `recharge__using_orders` is the proper variable to be setting to test this functionality of the data model.